### PR TITLE
ARMCC: Fixed missing parentheses in match-compiler-exe regexp.

### DIFF
--- a/CMake-armcc/custom-compiler-armcc.yaml
+++ b/CMake-armcc/custom-compiler-armcc.yaml
@@ -1,6 +1,6 @@
 aliases:
   - &armcc
-    match-compiler-exe: "(.*/)?armcc\\.exe?"
+    match-compiler-exe: "(.*/)?armcc(\\.exe)?"
     code-insight-target-name: arm
     include-dirs: ${compiler-exe-dir}/../include
     defines:


### PR DESCRIPTION
Thank you for this welcome new feature.

This pull request aims to fix the regexp used in "custom-compiler-armcc.yaml" with the following effect:
    ARMCC can now be detected on Linux systems as well as Windows.

Best regards