### PR TITLE
fix a few mistake in Open Watcom 2 definition

### DIFF
--- a/CMake-OpenWatcom2/openwatcom2.yaml
+++ b/CMake-OpenWatcom2/openwatcom2.yaml
@@ -24,7 +24,6 @@ compilers:
     match-compiler-exe: "(.*/)?wcl386(\\.exe)?"
     include-dirs:
       - "${compiler-exe-dir}/../h"
-      - "${compiler-exe-dir}/../h/os2"
     defines-text: "
 #define __X86__ 1
 #define __386__ 1
@@ -52,7 +51,6 @@ compilers:
 #define _M_I386 1
 #define _M_IX86 500
 #define __NT__ 1
-#define __WINDOWS_386__ 1
 #define _WIN32 1
 #define __FLAT__ 1
 #define M_386FM 1
@@ -77,7 +75,7 @@ compilers:
 #define _M_I86LM 1
 #define __WATCOMC__ 1280
 #define _INTEGRAL_MAX_BITS 64"
-  - description: OpenWatcom DOS target
+  - description: OpenWatcom 16-bit DOS target
     match-args: "-bt=dos"
     match-compiler-exe: "(.*/)?wcl(\\.exe)?"
     include-dirs: "${compiler-exe-dir}/../h"
@@ -99,8 +97,7 @@ compilers:
     match-args: "-bt=linux"
     match-compiler-exe: "(.*/)?wcl386(\\.exe)?"
     include-dirs:
-      - "${compiler-exe-dir}/../h"
-      - "${compiler-exe-dir}/../h/nt"
+      - "${compiler-exe-dir}/../lh"
     defines-text: "
 #define __X86__ 1
 #define __386__ 1
@@ -108,6 +105,7 @@ compilers:
 #define _M_I386 1
 #define _M_IX86 500
 #define __LINUX__ 1
+#define __UNIX__ 1
 #define __FLAT__ 1
 #define M_386FM 1
 #define _M_386FM 1


### PR DESCRIPTION
remove wrong macro `__WINDOWS_386__` which is defined for 16-bit Windows
fix include path to be correct for appropriate target