### PR TITLE
TI C6000 DSP CGT added

### DIFF
--- a/CMake-Texas-Instruments-C6000-CGT/.gitignore
+++ b/CMake-Texas-Instruments-C6000-CGT/.gitignore
@@ -1,0 +1,1 @@
+/cmake-build*/

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/.gitignore
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/CMake-Texas-Instruments-C6000-CGT.iml
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/CMake-Texas-Instruments-C6000-CGT.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/custom-compiler.xml
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/custom-compiler.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.jetbrains.cidr.lang.workspace.compiler.custom.CustomCompilerService">
+    <option name="definitionsFile" value="$PROJECT_DIR$/custom-compiler-c6000.yaml" />
+    <option name="enabled" value="true" />
+  </component>
+</project>

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/misc.xml
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/modules.xml
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/CMake-Texas-Instruments-C6000-CGT.iml" filepath="$PROJECT_DIR$/.idea/CMake-Texas-Instruments-C6000-CGT.iml" />
+    </modules>
+  </component>
+</project>

--- a/CMake-Texas-Instruments-C6000-CGT/.idea/vcs.xml
+++ b/CMake-Texas-Instruments-C6000-CGT/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/CMake-Texas-Instruments-C6000-CGT/CMakeLists.txt
+++ b/CMake-Texas-Instruments-C6000-CGT/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.21)
+set(CMAKE_SYSTEM_NAME Generic)
+# Trick CMake that the compiler always works
+set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_COMPILER_WORKS 1)
+# End of trick
+
+project(CMake-Texas-Instruments-C6000-CGT C CXX)
+
+# CMake 3.21 does not support TI compilers well, we need to make a couple of workarounds
+# Explicitly set include  and library directories
+find_program(TOOLCHAIN_PATH ${CMAKE_C_COMPILER})
+
+get_filename_component(TOOLCHAIN_PATH ${TOOLCHAIN_PATH} DIRECTORY) # Path to compiler
+get_filename_component(TOOLCHAIN_PATH ${TOOLCHAIN_PATH} DIRECTORY) # To parent dir
+message(STATUS "TOOLCHAIN_PATH: " ${TOOLCHAIN_PATH})
+
+include_directories(${TOOLCHAIN_PATH}/include)
+include_directories(${TOOLCHAIN_PATH}/include/libcxx)
+add_link_options(--library=${TOOLCHAIN_PATH}/lib/lnk.cmd --search_path=${TOOLCHAIN_PATH}/lib)
+# End of the workaround
+
+message(STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS})
+message(STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS})
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_C_STANDARD 99)
+
+add_executable(custom-compiler-test main.cpp cmain.c)

--- a/CMake-Texas-Instruments-C6000-CGT/CMakePresets.json
+++ b/CMake-Texas-Instruments-C6000-CGT/CMakePresets.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "configurePresets": [
+    {
+      "name": "cl6000",
+      "generator": "Ninja",
+      "binaryDir": "cmake-build-cl6000",
+      "vendor": {
+        "jetbrains.com/clion": {
+          "toolchain": "C6000"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "cl6000",
+      "displayName": "Texas Instruments CGT MSP430 V21",
+      "description": "Automatic preset for TI C6000 compiler",
+      "configurePreset": "cl6000"
+    }
+  ]
+}

--- a/CMake-Texas-Instruments-C6000-CGT/README.md
+++ b/CMake-Texas-Instruments-C6000-CGT/README.md
@@ -1,0 +1,20 @@
+Test project for Custom Compiler Feature
+===
+
+This project is an example how to use [TI C6000 CGT compiler](https://www.ti.com/tool/C6000-CGT) 
+with [CMake](https://cmake.org/) and [CLion](https://www.jetbrains.com/clion/)
+using [Custom Defined Compiler](https://blog.jetbrains.com/clion/2021/10/clion-2021-3-eap-custom-compiler/)
+
+There is a custom compiler definition file for the compiler: [custom-compiler-c6000.yaml](custom-compiler-c6000.yaml)
+
+## Disclaimer
+
+All the repository content is provided on an "AS IS" basis, without warranties or conditions of any kind.
+
+Contributors must have permission to contribute config files, either by ensuring that config files are open source or suitably licensed.
+
+Please note that JetBrains does not provide the described compilers or required licenses. The use of third-party
+compilers in CLion is subject to the licensing policies of their vendors.
+All trademarks, logos and brand names are the property of their respective owners. All company, product and service
+names used in this repository are for identification purposes only. Use of these names,trademarks and brands does not
+imply endorsement.

--- a/CMake-Texas-Instruments-C6000-CGT/cmain.c
+++ b/CMake-Texas-Instruments-C6000-CGT/cmain.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+#pragma message ("Compile C")
+int getInt();
+long long fn() {
+    return 3ll;
+}
+
+void fan(unsigned int x) {
+    const int res = x == 123;
+    if (x == 456) {}
+}
+
+void c_main() {
+    puts("Hello, World from C!");
+}

--- a/CMake-Texas-Instruments-C6000-CGT/custom-compiler-c6000.yaml
+++ b/CMake-Texas-Instruments-C6000-CGT/custom-compiler-c6000.yaml
@@ -1,0 +1,164 @@
+
+compilers:
+
+  - description: C11 TI CGT C6000-DSP v8.3
+    match-sources: ".*\\.c"
+    match-language: C
+    match-compiler-exe: "(.*/)?cl6x(\\.exe)?"
+    code-insight-target-name: C6000
+    include-dirs: ${compiler-exe-dir}/../include
+    defines-text: "
+#define __signed_chars__ 1	
+#define __STDC__ 1	
+#define __STDC_VERSION__ 199409L	
+#define __STDC_HOSTED__ 1	
+#define __TI_INT40_T__ 1	
+#define __TI_C99_COMPLEX_ENABLED__ 1	
+#define __STDC_NO_THREADS__ 1	
+#define __edg_front_end__ 1	
+#define __EDG_VERSION__ 413	
+#define __EDG_SIZE_TYPE__ unsigned int	
+#define __EDG_PTRDIFF_TYPE__ int	
+#define __VERSION__ \"EDG gcc 4.8 mode\"
+#define __CHAR16_TYPE__ unsigned short	
+#define __CHAR32_TYPE__ unsigned int	
+#define __TI_COMPILER_VERSION__ 8003012	
+#define __COMPILER_VERSION__ 8003012	
+#define _TMS320C6X 1	
+#define __TMS320C6X__ 1	
+#define _TMS320C64_PLUS 1	
+#define _TMS320C6400_PLUS 1	
+#define _TMS320C6400 1	
+#define _LITTLE_ENDIAN 1	
+#define __TI_ELFABI__ 1	
+#define __TI_TLS__ 1	
+#define __TI_32BIT_LONG__ 1	
+#define __SIZE_T_TYPE__ unsigned	
+#define __PTRDIFF_T_TYPE__ int	
+#define __WCHAR_T_TYPE__ unsigned short	
+#define __TI_EABI__ 1	
+#define __ELF__ 1	
+#define __little_endian__ 1	
+#define __LITTLE_ENDIAN__ 1	
+#define __TI_STRICT_ANSI_MODE__ 0	
+#define __TI_WCHAR_T_BITS__ 16	
+#define __TI_GNU_ATTRIBUTE_SUPPORT__ 1	
+#define __TI_STRICT_FP_MODE__ 1	
+#define __CHAR_BIT__ 8	
+#define __SCHAR_MAX__ 127	
+#define __SHRT_MAX__ 32767	
+#define __INT_MAX__ 2147483647	
+#define __LONG_MAX__ 2147483647	
+#define __LONG_LONG_MAX__ 9223372036854775807	
+#define __SIZEOF_INT__ 4	
+#define __SIZEOF_SHORT__ 2	
+#define __SIZEOF_LONG__ 4	
+#define __SIZEOF_LONG_LONG__ 8	
+#define __SIZEOF_WCHAR_T__ 2	
+#define __SIZEOF_FLOAT__ 4	
+#define __SIZEOF_DOUBLE__ 8	
+#define __SIZEOF_LONG_DOUBLE__ 8	
+#define __SIZEOF_SIZE_T__ 4	
+#define __SIZEOF_WINT_T__ 2	
+#define __SIZEOF_PTRDIFF_T__ 4	
+"
+
+  - description: C++14 TI CGT C6000-DSP v8.3
+    match-sources: ".*\\.cpp"
+    match-language: CPP
+    match-compiler-exe: "(.*/)?cl6x(\\.exe)?"
+    code-insight-target-name: C6000
+    include-dirs: ${compiler-exe-dir}/../include
+    defines-text: "
+#define __signed_chars__ 1	
+#define __STDC__ 1	
+#define __STDC_HOSTED__ 1	
+#define __cplusplus 201402L	
+#define _WCHAR_T 1	
+#define __CHAR16_T_AND_CHAR32_T 1	
+#define _BOOL 1	
+#define __ARRAY_OPERATORS 1	
+#define __PLACEMENT_DELETE 1	
+#define __EDG_RUNTIME_USES_NAMESPACES 1	
+#define __EDG_IA64_ABI 1	
+#define __EDG_IA64_ABI_VARIANT_CTORS_AND_DTORS_RETURN_THIS 1	
+#define __EDG_IA64_ABI_USE_VARIANT_INT_STATIC_INIT_GUARD 1	
+#define __cpp_initializer_lists 200806	
+#define __cpp_sized_deallocation 201309	
+#define __cpp_unicode_characters 200704	
+#define __cpp_aggregate_nsdmi 201304	
+#define __cpp_alias_templates 200704	
+#define __cpp_attributes 200809	
+#define __cpp_binary_literals 201304	
+#define __cpp_decltype 200707	
+#define __cpp_decltype_auto 201304	
+#define __cpp_delegating_constructors 200604	
+#define __cpp_generic_lambdas 201304	
+#define __cpp_inheriting_constructors 200802	
+#define __cpp_init_captures 201304	
+#define __cpp_lambdas 200907	
+#define __cpp_nsdmi 200809	
+#define __cpp_raw_strings 200710	
+#define __cpp_ref_qualifiers 200710	
+#define __cpp_return_type_deduction 201304	
+#define __cpp_rvalue_references 200610	
+#define __cpp_unicode_literals 200710	
+#define __cpp_user_defined_literals 200809	
+#define __cpp_variable_templates 201304	
+#define __cpp_variadic_templates 200704	
+#define __cpp_constexpr 201304	
+#define __cpp_range_based_for 200907	
+#define __cpp_static_assert 200410	
+#define __TI_INT40_T__ 1	
+#define __TI_C99_COMPLEX_ENABLED__ 1	
+#define __EDG_TYPE_TRAITS_ENABLED 1	
+#define __VARIADIC_TEMPLATES 1	
+#define __EDG_CONSTEXPR_ENABLED__ 1	
+#define __edg_front_end__ 1	
+#define __EDG_VERSION__ 413	
+#define __EDG_SIZE_TYPE__ unsigned int	
+#define __EDG_PTRDIFF_TYPE__ int	
+#define __GNUC_STDC_INLINE__ 1	
+#define __VERSION__ \"EDG g++ 4.8 mode\"
+#define __CHAR16_TYPE__ unsigned short	
+#define __CHAR32_TYPE__ unsigned int	
+#define __TI_COMPILER_VERSION__ 8003012	
+#define __COMPILER_VERSION__ 8003012	
+#define _TMS320C6X 1	
+#define __TMS320C6X__ 1	
+#define _TMS320C64_PLUS 1	
+#define _TMS320C6400_PLUS 1	
+#define _TMS320C6400 1	
+#define _LITTLE_ENDIAN 1	
+#define __TI_ELFABI__ 1	
+#define __TI_TLS__ 1	
+#define __TI_32BIT_LONG__ 1	
+#define __SIZE_T_TYPE__ unsigned	
+#define __PTRDIFF_T_TYPE__ int	
+#define __WCHAR_T_TYPE__ unsigned short	
+#define __TI_EABI__ 1	
+#define __ELF__ 1	
+#define __little_endian__ 1	
+#define __LITTLE_ENDIAN__ 1	
+#define __TI_STRICT_ANSI_MODE__ 0	
+#define __TI_WCHAR_T_BITS__ 16	
+#define __TI_GNU_ATTRIBUTE_SUPPORT__ 1	
+#define __TI_STRICT_FP_MODE__ 1	
+#define __CHAR_BIT__ 8	
+#define __SCHAR_MAX__ 127	
+#define __SHRT_MAX__ 32767	
+#define __INT_MAX__ 2147483647	
+#define __LONG_MAX__ 2147483647	
+#define __LONG_LONG_MAX__ 9223372036854775807	
+#define __SIZEOF_INT__ 4	
+#define __SIZEOF_SHORT__ 2	
+#define __SIZEOF_LONG__ 4	
+#define __SIZEOF_LONG_LONG__ 8	
+#define __SIZEOF_WCHAR_T__ 2	
+#define __SIZEOF_FLOAT__ 4	
+#define __SIZEOF_DOUBLE__ 8	
+#define __SIZEOF_LONG_DOUBLE__ 8	
+#define __SIZEOF_SIZE_T__ 4	
+#define __SIZEOF_WINT_T__ 2	
+#define __SIZEOF_PTRDIFF_T__ 4
+"

--- a/CMake-Texas-Instruments-C6000-CGT/main.cpp
+++ b/CMake-Texas-Instruments-C6000-CGT/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+#pragma message ("Compile C++")
+extern "C" void c_main(void);
+
+int main() {
+    std::cout << "Hello, World, from C++!" << std::endl;
+    c_main();
+    return 0;
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ imply endorsement.
     * Compiler definition file: [custom-compiler-sdcc-stm8.yaml](CMake-SDCC/custom-compiler-sdcc-stm8.yaml)
   * Host Platforms: Windows, Linux, Mac
   * Target Platform: STM8 MCU
+* [CMake-Texas-Instruments-C6000-CGT](CMake-Texas-Instruments-C6000-CGT)
+  * Build System: [CMake](https://cmake.org/)
+  * Compiler: [TI C6000 CGT compiler](https://www.ti.com/tool/C6000-CGT)
+    * Compiler definition file: [custom-compiler-c6000.yaml](CMake-Texas-Instruments-C6000-CGT/custom-compiler-c6000.yaml)
+  * Host Platforms: Windows, Linux, Mac
+  * Target Platform: C6000 DSP
 * [CMake-Texas-Instruments-MSP430-CGT](CMake-Texas-Instruments-MSP430-CGT)
   * Build System: [CMake](https://cmake.org/)
   * Compiler: [TI MSP430 CGT compiler](https://www.ti.com/tool/MSP-CGT)
@@ -69,4 +75,3 @@ imply endorsement.
     * Compiler definition gathering script(Python): [custom_compiler_yaml_tasking.py](Makefile-Tasking-Tricore/custom_compiler_yaml_tasking.py)
   * Host Platforms: Windows, Linux
   * Target Platform: Infineon
-  


### PR DESCRIPTION
Added support for TI C6000 CGT - Series of Digital Signal Processors (TMS320C6x, https://www.ti.com/tool/C6000-CGT)